### PR TITLE
- persist the logged-in session across refreshes via localStorage in …

### DIFF
--- a/Online_Bullying_System_Backend/app/crud/complaint.py
+++ b/Online_Bullying_System_Backend/app/crud/complaint.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from app.models import (
+    db,
+    Complaint,
+    ComplaintComment,
+    ComplaintStatus,
+    User,
+    now_kuala_lumpur,
+)
+
+
+def _generate_reference_code() -> str:
+    last = (
+        db.session.query(Complaint.reference_code)
+        .order_by(Complaint.id.desc())
+        .limit(1)
+        .scalar()
+    )
+
+    if not last:
+        return "A0001"
+
+    # Split into prefix letters and numeric portion
+    prefix = "".join(ch for ch in last if ch.isalpha())
+    digits = "".join(ch for ch in last if ch.isdigit())
+
+    if not prefix or not digits:
+        # Fallback if previous code doesn't match expected format
+        prefix = "A"
+        digits = "0000"
+
+    number = int(digits)
+
+    if number < 9999:
+        number += 1
+        return f"{prefix}{number:04d}"
+
+    # number reached 9999, reset digits and advance prefix
+    number = 1
+    letters = list(prefix)
+
+    idx = len(letters) - 1
+    while idx >= 0:
+        if letters[idx] != "Z":
+            letters[idx] = chr(ord(letters[idx]) + 1)
+            break
+        letters[idx] = "A"
+        idx -= 1
+    else:
+        # all letters were Z, prepend a new letter
+        letters.insert(0, "A")
+
+    new_prefix = "".join(letters)
+    return f"{new_prefix}{number:04d}"
+
+
+def _parse_incident_date(value: Optional[str]):
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def create_complaint(data: Dict[str, Any]) -> Complaint:
+    anonymous = bool(data.get("anonymous"))
+    user_id = data.get("user_id")
+
+    user: Optional[User] = None
+    if user_id:
+        user = User.query.get(user_id)
+
+    provided_name = (data.get("student_name") or "").strip()
+    base_name = provided_name or (user.username if user else "Unknown Student")
+
+    attachments = data.get("attachments") or []
+    if isinstance(attachments, list):
+        # Ensure attachments is a list of simple serialisable dicts
+        normalised: List[Dict[str, Any]] = []
+        for item in attachments:
+            if isinstance(item, dict):
+                normalised.append(
+                    {
+                        "name": item.get("name"),
+                        "size": item.get("size"),
+                        "type": item.get("type"),
+                    }
+                )
+            else:
+                normalised.append({"name": str(item)})
+        attachments = normalised
+    else:
+        attachments = []
+
+    status_value = data.get("status", ComplaintStatus.NEW.value)
+    if isinstance(status_value, str):
+        try:
+            status_enum = ComplaintStatus(status_value.lower())
+        except ValueError:
+            # backward compatibility for legacy "pending"
+            if status_value.lower() == "pending":
+                status_enum = ComplaintStatus.NEW
+            else:
+                status_enum = ComplaintStatus.NEW
+    elif isinstance(status_value, ComplaintStatus):
+        status_enum = status_value
+    else:
+        status_enum = ComplaintStatus.NEW
+
+    now_kl = now_kuala_lumpur()
+    complaint = Complaint(
+        reference_code=_generate_reference_code(),
+        user_id=user.id if user else None,
+        student_name=base_name,
+        anonymous=anonymous,
+        incident_type=data.get("incident_type") or data.get("incidentType") or "unspecified",
+        description=data.get("description") or "",
+        room_number=data.get("room_number") or data.get("roomNumber"),
+        incident_date=_parse_incident_date(data.get("incident_date") or data.get("incidentDate")),
+        witnesses=data.get("witnesses"),
+        attachments=attachments,
+        status=status_enum.value if isinstance(status_enum, ComplaintStatus) else status_enum,
+        submitted_at=now_kl,
+        updated_at=now_kl,
+    )
+    db.session.add(complaint)
+    db.session.commit()
+    return complaint
+
+
+def get_complaint_by_id(complaint_id: int, include_comments: bool = False) -> Optional[Dict[str, Any]]:
+    complaint = Complaint.query.get(complaint_id)
+    if not complaint:
+        return None
+    return complaint.to_dict(include_comments=include_comments)
+
+
+def get_complaints_for_user(user_id: int, include_comments: bool = False) -> List[Dict[str, Any]]:
+    complaints = (
+        Complaint.query.filter_by(user_id=user_id)
+        .order_by(Complaint.submitted_at.desc())
+        .all()
+    )
+    return [complaint.to_dict(include_comments=include_comments) for complaint in complaints]
+
+
+def get_all_complaints(include_comments: bool = False) -> List[Dict[str, Any]]:
+    complaints = Complaint.query.order_by(Complaint.submitted_at.desc()).all()
+    return [complaint.to_dict(include_comments=include_comments) for complaint in complaints]
+
+
+def add_comment(
+    complaint_id: int,
+    author_id: Optional[int],
+    message: str,
+) -> Optional[ComplaintComment]:
+    complaint = Complaint.query.get(complaint_id)
+    if not complaint:
+        return None
+
+    user = User.query.get(author_id) if author_id else None
+    author_name = user.username if user else "System"
+    author_role = user.role.value if user else "SYSTEM"
+
+    comment = ComplaintComment(
+        complaint_id=complaint.id,
+        author_id=user.id if user else None,
+        author_name=author_name,
+        author_role=author_role,
+        message=message,
+        created_at=now_kuala_lumpur(),
+    )
+    db.session.add(comment)
+    db.session.commit()
+    return comment
+
+
+def get_comments(complaint_id: int) -> List[Dict[str, Any]]:
+    comments = (
+        ComplaintComment.query.filter_by(complaint_id=complaint_id)
+        .order_by(ComplaintComment.created_at.asc())
+        .all()
+    )
+    return [comment.to_dict() for comment in comments]
+
+
+def update_complaint_status(complaint_id: int, status_value: str) -> Optional[Complaint]:
+    complaint = Complaint.query.get(complaint_id)
+    if not complaint:
+        return None
+
+    try:
+        status_enum = ComplaintStatus(status_value.lower())
+    except ValueError:
+        if status_value.lower() == "pending":
+            status_enum = ComplaintStatus.NEW
+        else:
+            raise
+
+    complaint.status = status_enum.value
+    complaint.updated_at = now_kuala_lumpur()
+    db.session.commit()
+    return complaint

--- a/Online_Bullying_System_Backend/app/models.py
+++ b/Online_Bullying_System_Backend/app/models.py
@@ -1,6 +1,14 @@
 from app import db
 import enum
+from datetime import datetime, date
+from zoneinfo import ZoneInfo
 from werkzeug.security import generate_password_hash, check_password_hash
+
+KUALA_LUMPUR_TZ = ZoneInfo("Asia/Kuala_Lumpur")
+
+
+def now_kuala_lumpur() -> datetime:
+    return datetime.now(KUALA_LUMPUR_TZ)
 
 class UserRole(enum.Enum):
     STUDENT = "STUDENT"
@@ -14,6 +22,18 @@ class User(db.Model):
     role = db.Column(db.Enum(UserRole), nullable=False, default=UserRole.STUDENT)
     password_hash = db.Column(db.String(512), nullable=False)
     avatar_url = db.Column(db.String(512), nullable=True)
+    complaints = db.relationship(
+        "Complaint",
+        backref="user",
+        lazy="dynamic",
+        cascade="all, delete-orphan"
+    )
+    comments = db.relationship(
+        "ComplaintComment",
+        backref="author",
+        lazy="dynamic",
+        cascade="all, delete-orphan"
+    )
 
     def set_password(self, password: str) -> None:
         self.password_hash = generate_password_hash(password)
@@ -31,3 +51,99 @@ class User(db.Model):
             # do not include password_hash
         }
         return data
+
+
+class ComplaintStatus(enum.Enum):
+    NEW = "new"
+    IN_PROGRESS = "in_progress"
+    RESOLVED = "resolved"
+    REJECTED = "rejected"
+
+
+class Complaint(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    reference_code = db.Column(db.String(32), unique=True, nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    student_name = db.Column(db.String(120), nullable=False)
+    anonymous = db.Column(db.Boolean, nullable=False, default=False)
+    incident_type = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text, nullable=False)
+    room_number = db.Column(db.String(64), nullable=True)
+    incident_date = db.Column(db.Date, nullable=True)
+    witnesses = db.Column(db.Text, nullable=True)
+    attachments = db.Column(db.JSON, nullable=True)
+    status = db.Column(
+        db.Enum(
+            ComplaintStatus,
+            values_callable=lambda enum: [member.value for member in enum],
+            native_enum=False,
+            validate_strings=True,
+        ),
+        nullable=False,
+        default=ComplaintStatus.NEW.value,
+    )
+    submitted_at = db.Column(db.DateTime(timezone=True), nullable=False, default=now_kuala_lumpur)
+    updated_at = db.Column(
+        db.DateTime(timezone=True), nullable=False, default=now_kuala_lumpur, onupdate=now_kuala_lumpur
+    )
+    comments = db.relationship(
+        "ComplaintComment",
+        backref="complaint",
+        cascade="all, delete-orphan",
+        lazy="dynamic",
+        order_by="ComplaintComment.created_at"
+    )
+
+    def student_display_name(self) -> str:
+        if self.anonymous:
+            return "Anonymously"
+        return self.student_name
+
+    def to_dict(self, include_comments: bool = False):
+        status_value = self.status.value if isinstance(self.status, ComplaintStatus) else self.status
+        if isinstance(status_value, str) and status_value.lower() == "pending":
+            status_value = ComplaintStatus.NEW.value
+
+        data = {
+            "id": self.id,
+            "reference_code": self.reference_code,
+            "student_name": self.student_display_name(),
+            "student_real_name": self.student_name,
+            "anonymous": self.anonymous,
+            "incident_type": self.incident_type,
+            "description": self.description,
+            "room_number": self.room_number,
+            "incident_date": self.incident_date.isoformat() if self.incident_date else None,
+            "witnesses": self.witnesses,
+            "attachments": self.attachments or [],
+            "status": status_value,
+            "submitted_at": self.submitted_at.isoformat() if isinstance(self.submitted_at, (datetime, date)) else self.submitted_at,
+            "updated_at": self.updated_at.isoformat() if isinstance(self.updated_at, (datetime, date)) else self.updated_at,
+            "user_id": self.user_id,
+        }
+        if include_comments:
+            data["comments"] = [
+                comment.to_dict() for comment in self.comments.order_by(ComplaintComment.created_at.asc())
+            ]
+        return data
+
+
+class ComplaintComment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    complaint_id = db.Column(db.Integer, db.ForeignKey("complaint.id"), nullable=False)
+    author_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=True)
+    author_name = db.Column(db.String(120), nullable=False)
+    author_role = db.Column(db.String(32), nullable=True)
+    message = db.Column(db.Text, nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False, default=now_kuala_lumpur)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "complaint_id": self.complaint_id,
+            "author_id": self.author_id,
+            "author_name": self.author_name,
+            "author_role": self.author_role,
+            "message": self.message,
+            "created_at": self.created_at.isoformat() if isinstance(self.created_at, (datetime, date)) else self.created_at,
+        }

--- a/Online_Bullying_System_Backend/migrations/versions/add_complaint_status_new_value.py
+++ b/Online_Bullying_System_Backend/migrations/versions/add_complaint_status_new_value.py
@@ -1,0 +1,22 @@
+"""add new status value"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'add_complaint_status_new_value'
+down_revision = 'add_complaints_tables'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE complaintstatus ADD VALUE IF NOT EXISTS 'new'")
+    op.execute("ALTER TABLE complaint ALTER COLUMN status DROP DEFAULT")
+    op.execute("UPDATE complaint SET status='new' WHERE status='pending'")
+    op.execute("ALTER TABLE complaint ALTER COLUMN status SET DEFAULT 'new'")
+
+
+def downgrade():
+    op.execute("ALTER TABLE complaint ALTER COLUMN status DROP DEFAULT")
+    op.execute("UPDATE complaint SET status='pending' WHERE status='new'")
+    op.execute("ALTER TABLE complaint ALTER COLUMN status SET DEFAULT 'pending'")

--- a/Online_Bullying_System_Backend/migrations/versions/add_complaints_tables.py
+++ b/Online_Bullying_System_Backend/migrations/versions/add_complaints_tables.py
@@ -1,0 +1,51 @@
+"""add complaints and complaint_comments tables"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import expression
+
+# revision identifiers, used by Alembic.
+revision = 'add_complaints_tables'
+down_revision = 'add_avatar_url_to_user'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    status_enum = sa.Enum('new', 'in_progress', 'resolved', name='complaintstatus')
+
+    op.create_table(
+        'complaint',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('reference_code', sa.String(length=32), nullable=False),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=True),
+        sa.Column('student_name', sa.String(length=120), nullable=False),
+        sa.Column('anonymous', sa.Boolean(), nullable=False, server_default=expression.false()),
+        sa.Column('incident_type', sa.String(length=120), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False),
+        sa.Column('room_number', sa.String(length=64), nullable=True),
+        sa.Column('incident_date', sa.Date(), nullable=True),
+        sa.Column('witnesses', sa.Text(), nullable=True),
+        sa.Column('attachments', sa.JSON(), nullable=True),
+        sa.Column('status', status_enum, nullable=False, server_default='new'),
+        sa.Column('submitted_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint('reference_code'),
+    )
+
+    op.create_table(
+        'complaint_comment',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('complaint_id', sa.Integer(), sa.ForeignKey('complaint.id'), nullable=False),
+        sa.Column('author_id', sa.Integer(), sa.ForeignKey('user.id'), nullable=True),
+        sa.Column('author_name', sa.String(length=120), nullable=False),
+        sa.Column('author_role', sa.String(length=32), nullable=True),
+        sa.Column('message', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade():
+    op.drop_table('complaint_comment')
+    op.drop_table('complaint')
+    status_enum = sa.Enum('pending', 'in_progress', 'resolved', name='complaintstatus')
+    status_enum.drop(op.get_bind(), checkfirst=False)

--- a/Online_Bullying_System_Backend/migrations/versions/add_rejected_status_to_complaint.py
+++ b/Online_Bullying_System_Backend/migrations/versions/add_rejected_status_to_complaint.py
@@ -1,0 +1,18 @@
+"""add rejected status value"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "add_rejected_status_to_complaint"
+down_revision = "add_complaint_status_new_value"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE complaintstatus ADD VALUE IF NOT EXISTS 'rejected'")
+
+
+def downgrade():
+    # map any rejected complaints back to new before downgrading
+    op.execute("UPDATE complaint SET status='new' WHERE status='rejected'")

--- a/Online_Bullying_System_Frontend/src/App.css
+++ b/Online_Bullying_System_Frontend/src/App.css
@@ -883,6 +883,42 @@ input:checked + .slider:before {
   font-size: 0.9em;
 }
 
+.attachment-trigger-btn {
+  display: inline-block;
+  padding: 0.65rem 1.2rem;
+  background: #667eea;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  margin-right: 12px;
+  transition: background 0.2s;
+}
+
+.attachment-trigger-btn:hover,
+.attachment-trigger-btn:focus {
+  background: #5466d8;
+  outline: none;
+}
+
+.attachment-summary {
+  font-size: 0.95rem;
+  color: #555;
+}
+
+.form-error {
+  margin-bottom: 1rem;
+  color: #c0392b;
+  font-weight: 600;
+}
+
+.form-success {
+  margin-bottom: 1rem;
+  color: #2d7d46;
+  font-weight: 600;
+}
+
 /* Submit Complain Styles end */
 
 /* Complaint Status Styles */
@@ -917,6 +953,13 @@ input:checked + .slider:before {
   background: #f8f9fa;
 }
 
+.complaint-card.is-highlighted {
+  border-color: #4c6ef5;
+  box-shadow: 0 0 0 3px rgba(76, 110, 245, 0.2);
+  background: #eef3ff;
+  transition: box-shadow 0.3s ease, background 0.3s ease;
+}
+
 .complaint-header {
   display: flex;
   justify-content: space-between;
@@ -929,17 +972,34 @@ input:checked + .slider:before {
   margin: 0;
 }
 
+.complaint-subtitle {
+  margin: 4px 0 0;
+  color: #7f8c8d;
+  font-size: 0.9rem;
+}
+
 .status {
   padding: 0.3rem 0.8rem;
   border-radius: 20px;
   font-size: 0.8rem;
   font-weight: 600;
   text-transform: uppercase;
+  align-self: flex-start;
 }
 
 .status.pending {
   background: #fff3cd;
   color: #856404;
+}
+
+.status.new {
+  background: #fff3cd;
+  color: #856404;
+}
+
+.status.in_progress {
+  background: #cce5ff;
+  color: #004085;
 }
 
 .status.investigating {
@@ -952,9 +1012,181 @@ input:checked + .slider:before {
   color: #155724;
 }
 
+.status.rejected {
+  background: #f8d7da;
+  color: #721c24;
+}
+
+.status-notice {
+  margin-bottom: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.status-notice--new {
+  background: #fff5d9;
+  border: 1px solid #ffe8ac;
+  color: #8a6d1c;
+}
+
+.status-notice--in_progress {
+  background: #e7f1ff;
+  border: 1px solid #c2dcff;
+  color: #0b48a8;
+}
+
+.status-notice--resolved {
+  background: #e3f7ea;
+  border: 1px solid #c2e7cf;
+  color: #196232;
+}
+
+.status-notice--rejected {
+  background: #fbe5e7;
+  border: 1px solid #f1b7bd;
+  color: #8b1c29;
+}
+
 .complaint-details p {
   margin: 0.5rem 0;
   color: #495057;
+}
+
+.complaint-description {
+  margin-top: 0.5rem;
+  white-space: pre-line;
+}
+
+.complaint-attachments {
+  margin-top: 0.75rem;
+}
+
+.complaint-attachments ul {
+  margin: 0.4rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.toggle-comments-btn {
+  margin-top: 1rem;
+  background: transparent;
+  border: 1px solid #667eea;
+  color: #667eea;
+  border-radius: 6px;
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s, color 0.2s;
+}
+
+.toggle-comments-btn:hover,
+.toggle-comments-btn:focus {
+  background: #667eea;
+  color: #fff;
+  outline: none;
+}
+
+.complaint-comments {
+  margin-top: 1rem;
+  border-top: 1px solid #e5e8f0;
+  padding-top: 1rem;
+}
+
+.complaint-comments h4 {
+  margin-bottom: 0.6rem;
+  color: #2c3e50;
+}
+
+.no-comments {
+  color: #7f8c8d;
+  margin: 0.4rem 0 1rem;
+}
+
+.comment-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.comment-item {
+  background: #f4f6ff;
+  border-radius: 8px;
+  padding: 0.75rem;
+  border: 1px solid #dfe4fc;
+}
+
+.comment-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.comment-author {
+  font-weight: 600;
+  color: #2c3e50;
+}
+
+.comment-role {
+  color: #7f8c8d;
+  font-weight: 500;
+}
+
+.comment-date {
+  color: #95a5a6;
+  font-size: 0.8rem;
+}
+
+.comment-message {
+  margin: 0;
+  color: #34495e;
+  white-space: pre-line;
+}
+
+.comment-form {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.comment-form textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #cbd2ff;
+  resize: vertical;
+  font-size: 0.95rem;
+  min-height: 80px;
+}
+
+.comment-form button {
+  align-self: flex-end;
+  background: #667eea;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.45rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.comment-form button:hover,
+.comment-form button:focus {
+  background: #5466d8;
+  outline: none;
+}
+
+.comment-error {
+  color: #c0392b;
+  font-size: 0.9rem;
+  margin: 0;
 }
 
 /* Resources Styles */
@@ -1343,11 +1575,19 @@ input:checked + .slider:before {
 }
 
 .history-item {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
   background: #fafafa;
   margin-bottom: 14px;
   padding: 14px;
   border-radius: 8px;
   border: 1px solid #f0f0f0;
+}
+
+.history-content {
+  flex: 1 1 240px;
 }
 
 .history-field {
@@ -1358,6 +1598,39 @@ input:checked + .slider:before {
 .history-field pre,
 .history-field .description {
   white-space: pre-wrap;
+}
+
+.history-description {
+  white-space: pre-wrap;
+  margin-bottom: 0;
+}
+
+.history-actions {
+  margin-top: 0;
+  display: flex;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.history-view-button {
+  background: #4c6ef5;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.history-view-button:hover {
+  background: #3b5bdb;
+  transform: translateY(-1px);
+}
+
+.history-view-button:focus {
+  outline: 2px solid #3b5bdb;
+  outline-offset: 2px;
 }
 /* Profile Page Styles end */
 

--- a/Online_Bullying_System_Frontend/src/components/CheckStatus.jsx
+++ b/Online_Bullying_System_Frontend/src/components/CheckStatus.jsx
@@ -1,39 +1,293 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 
-// Check Status Component
-function ComplaintStatus({ complaints }) {
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
+const formatDate = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleDateString(undefined, { dateStyle: 'medium' });
+};
+
+const normaliseStatus = (status = '') =>
+  status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const STATUS_KEYS = ['new', 'in_progress', 'resolved', 'rejected'];
+
+const STATUS_NOTICE = {
+  new: 'We have received your report and it is awaiting review.',
+  in_progress: 'Our team is currently reviewing your report. We will notify you once there is an update.',
+  resolved: 'Your report has been resolved. Thank you for helping us keep the community safe.',
+  rejected:
+    'This report was rejected. Please review the feedback from school staff and submit a new report if needed.',
+};
+
+const deriveStatusInfo = (value) => {
+  const raw = (value || '').toString().trim();
+  const normalized = raw.toLowerCase().replace(/\s+/g, '_');
+  const canonical =
+    normalized === 'pending'
+      ? 'new'
+      : STATUS_KEYS.includes(normalized)
+      ? normalized
+      : normalized;
+
+  const fallbackClass = STATUS_KEYS.includes(canonical) ? canonical : 'new';
+  const labelSource = STATUS_KEYS.includes(canonical) ? canonical : normalized || raw;
+
+  return {
+    raw,
+    canonical,
+    statusClass: fallbackClass,
+    label: normaliseStatus(labelSource || 'new'),
+    notice: STATUS_NOTICE[STATUS_KEYS.includes(canonical) ? canonical : ''] || null,
+  };
+};
+
+function ComplaintStatus({ complaints = [], loading, error, onAddComment, currentUser }) {
+  const [commentDrafts, setCommentDrafts] = useState({});
+  const [commentErrors, setCommentErrors] = useState({});
+  const [commentSubmitting, setCommentSubmitting] = useState({});
+  const [expanded, setExpanded] = useState({});
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [focusedComplaintId, setFocusedComplaintId] = useState(() => location.state?.complaintId || null);
+  const complaintRefs = useRef({});
+
+  const handleToggleExpanded = (id) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const handleDraftChange = (id, value) => {
+    setCommentDrafts((prev) => ({ ...prev, [id]: value }));
+    setCommentErrors((prev) => ({ ...prev, [id]: null }));
+  };
+
+  const handleCommentSubmit = async (complaintId) => {
+    const draft = (commentDrafts[complaintId] || '').trim();
+    if (!draft) {
+      setCommentErrors((prev) => ({
+        ...prev,
+        [complaintId]: 'Please enter a comment before submitting.',
+      }));
+      return;
+    }
+    if (!onAddComment) return;
+
+    setCommentErrors((prev) => ({ ...prev, [complaintId]: null }));
+    setCommentSubmitting((prev) => ({ ...prev, [complaintId]: true }));
+    try {
+      await onAddComment(complaintId, draft);
+      setCommentDrafts((prev) => ({ ...prev, [complaintId]: '' }));
+      setExpanded((prev) => ({ ...prev, [complaintId]: true }));
+    } catch (err) {
+      const message =
+        err?.response?.data?.error ||
+        err?.message ||
+        'Unable to add comment. Please try again.';
+      setCommentErrors((prev) => ({ ...prev, [complaintId]: message }));
+    } finally {
+      setCommentSubmitting((prev) => ({ ...prev, [complaintId]: false }));
+    }
+  };
+
+  useEffect(() => {
+    const complaintId = location.state?.complaintId;
+    if (!complaintId) return;
+    setFocusedComplaintId(complaintId);
+    setExpanded((prev) => ({ ...prev, [complaintId]: true }));
+    const clearState = setTimeout(() => {
+      navigate(location.pathname, { replace: true });
+    }, 0);
+    return () => clearTimeout(clearState);
+  }, [location, navigate]);
+
+  useEffect(() => {
+    if (!focusedComplaintId) return;
+    const node = complaintRefs.current[focusedComplaintId];
+    if (!node) return;
+    node.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    node.classList.add('is-highlighted');
+    const removeHighlight = setTimeout(() => {
+      node.classList.remove('is-highlighted');
+    }, 3000);
+    const clearFocus = setTimeout(() => {
+      setFocusedComplaintId(null);
+    }, 3500);
+    return () => {
+      clearTimeout(removeHighlight);
+      clearTimeout(clearFocus);
+    };
+  }, [focusedComplaintId, complaints]);
+
   return (
     <div className="complaint-status">
       <h2>Complaint Status</h2>
 
-      {complaints.length === 0 ? (
+      {loading ? (
+        <div className="no-complaints">
+          <p>Loading complaints...</p>
+        </div>
+      ) : error ? (
+        <div className="no-complaints">
+          <p>{error}</p>
+        </div>
+      ) : complaints.length === 0 ? (
         <div className="no-complaints">
           <p>No complaints submitted yet.</p>
         </div>
       ) : (
         <div className="complaints-list">
-          {complaints.map(complaint => (
-            <div key={complaint.id} className="complaint-card">
-              <div className="complaint-header">
-                <h3>Complaint #{complaint.id}</h3>
-                <span className={`status ${complaint.status}`}>
-                  {complaint.status.toUpperCase()}
-                </span>
-              </div>
-              <div className="complaint-details">
-                <p><strong>Type:</strong> {complaint.incidentType}</p>
-                <p><strong>Submitted:</strong> {complaint.submittedAt}</p>
-                <p><strong>Room:</strong> {complaint.roomNumber}</p>
-                {!complaint.anonymous && (
-                  <p><strong>Student:</strong> {complaint.studentName}</p>
+          {complaints.map((complaint) => {
+            const statusInfo = deriveStatusInfo(complaint.status);
+            const comments = complaint.comments || [];
+            const incidentType = complaint.incident_type || complaint.incidentType;
+            const submittedAt = complaint.submitted_at || complaint.submittedAt;
+            const roomNumber = complaint.room_number || complaint.roomNumber;
+            const studentName = complaint.student_name || complaint.studentName;
+            const incidentDate = complaint.incident_date || complaint.incidentDate;
+            const attachments = complaint.attachments || [];
+            const isExpanded = expanded[complaint.id] ?? true;
+            const draft = commentDrafts[complaint.id] || '';
+
+            return (
+              <div
+                key={complaint.id}
+                className={`complaint-card${focusedComplaintId === complaint.id ? ' is-highlighted' : ''}`}
+                ref={(el) => {
+                  if (el) {
+                    complaintRefs.current[complaint.id] = el;
+                  } else {
+                    delete complaintRefs.current[complaint.id];
+                  }
+                }}
+              >
+                <div className="complaint-header">
+                  <div>
+                    <h3>
+                      Complaint{' '}
+                      {complaint.reference_code
+                        ? `#${complaint.reference_code}`
+                        : `#${complaint.id}`}
+                    </h3>
+                    <p className="complaint-subtitle">
+                      Submitted: {formatDateTime(submittedAt)}
+                    </p>
+                  </div>
+                  <span className={`status ${statusInfo.statusClass}`}>
+                    {statusInfo.label}
+                  </span>
+                </div>
+
+                <div className="complaint-details">
+                  {statusInfo.notice && (
+                    <div className={`status-notice status-notice--${statusInfo.statusClass}`}>
+                      {statusInfo.notice}
+                    </div>
+                  )}
+                  <p><strong>Type:</strong> {incidentType || '—'}</p>
+                  <p><strong>Incident Date:</strong> {formatDate(incidentDate)}</p>
+                  <p><strong>Room:</strong> {roomNumber || '—'}</p>
+                  <p><strong>Student:</strong> {studentName || '—'}</p>
+                  <p className="complaint-description">
+                    <strong>Description:</strong> {complaint.description || '—'}
+                  </p>
+                  {complaint.witnesses && (
+                    <p><strong>Witnesses:</strong> {complaint.witnesses}</p>
+                  )}
+                  {attachments.length > 0 && (
+                    <div className="complaint-attachments">
+                      <strong>Attachments:</strong>
+                      <ul>
+                        {attachments.map((file, idx) => {
+                          const label =
+                            typeof file === 'string'
+                              ? file
+                              : file?.name || 'Attachment';
+                          return (
+                            <li key={`${complaint.id}-att-${idx}`}>
+                              {label}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+
+                <button
+                  type="button"
+                  className="toggle-comments-btn"
+                  onClick={() => handleToggleExpanded(complaint.id)}
+                >
+                  {isExpanded ? 'Hide Comments' : `View Comments (${comments.length})`}
+                </button>
+
+                {isExpanded && (
+                  <div className="complaint-comments">
+                    <h4>Comments</h4>
+                    {comments.length === 0 ? (
+                      <p className="no-comments">No comments yet.</p>
+                    ) : (
+                      <ul className="comment-list">
+                        {comments.map((comment) => (
+                          <li key={comment.id} className="comment-item">
+                            <div className="comment-meta">
+                              <span className="comment-author">
+                                {comment.author_name}
+                                {comment.author_role && (
+                                  <span className="comment-role"> ({normaliseStatus(comment.author_role.toLowerCase())})</span>
+                                )}
+                              </span>
+                              <span className="comment-date">
+                                {formatDateTime(comment.created_at)}
+                              </span>
+                            </div>
+                            <p className="comment-message">{comment.message}</p>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+
+                    {currentUser && (
+                      <div className="comment-form">
+                        <textarea
+                          rows="3"
+                          placeholder="Leave a comment..."
+                          value={draft}
+                          onChange={(e) => handleDraftChange(complaint.id, e.target.value)}
+                          disabled={commentSubmitting[complaint.id]}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => handleCommentSubmit(complaint.id)}
+                          disabled={commentSubmitting[complaint.id]}
+                        >
+                          {commentSubmitting[complaint.id] ? 'Posting...' : 'Post Comment'}
+                        </button>
+                        {commentErrors[complaint.id] && (
+                          <p className="comment-error">{commentErrors[complaint.id]}</p>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>
-  )
+  );
 }
 
-export {ComplaintStatus}
+export { ComplaintStatus };

--- a/Online_Bullying_System_Frontend/src/components/StudentProfilePage.jsx
+++ b/Online_Bullying_System_Frontend/src/components/StudentProfilePage.jsx
@@ -4,6 +4,16 @@ import { getUser, uploadUserAvatar, deleteUserAvatar, changeUserPassword, toAbso
 
 const MAX_AVATAR_SIZE_BYTES = 4 * 1024 * 1024; // 4 MB
 
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+};
+
 function StudentProfilePage({ complaints = [], showHistory = true, currentUser, onUserUpdate }) {
   const [activeTab, setActiveTab] = useState('account');
   const [showReset, setShowReset] = useState(false);
@@ -421,14 +431,27 @@ function StudentProfilePage({ complaints = [], showHistory = true, currentUser, 
                 <div className="no-complaints">No complaints submitted yet.</div>
               ) : (
                 <ul className="history-list">
-                  {complaints.map((c) => (
-                    <li key={c.id} className="history-item">
-                      <div className="history-field"><strong>Title:</strong> {c.title || 'No Title'}</div>
-                      <div className="history-field"><strong>Status:</strong> {c.status}</div>
-                      <div className="history-field"><strong>Date:</strong> {c.submittedAt}</div>
-                      <div className="history-field" style={{ whiteSpace: "pre-wrap" }}><strong>Description:</strong> {c.description}</div>
-                    </li>
-                  ))}
+                  {complaints.map((c) => {
+                    const submittedAt = c.submitted_at || c.submittedAt;
+                    return (
+                      <li key={c.id} className="history-item">
+                        <div className="history-content">
+                          <div className="history-field"><strong>Status:</strong> {c.status}</div>
+                          <div className="history-field"><strong>Date:</strong> {formatDateTime(submittedAt)}</div>
+                          <div className="history-field history-description"><strong>Description:</strong> {c.description}</div>
+                        </div>
+                        <div className="history-actions">
+                          <button
+                            type="button"
+                            className="history-view-button"
+                            onClick={() => navigate('/status', { state: { complaintId: c.id } })}
+                          >
+                            View
+                          </button>
+                        </div>
+                      </li>
+                    );
+                  })}
                 </ul>
               )}
             </div>

--- a/Online_Bullying_System_Frontend/src/services/api.js
+++ b/Online_Bullying_System_Frontend/src/services/api.js
@@ -64,6 +64,32 @@ export async function deleteUserAvatar(id) {
   return res.data;
 }
 
+// Complaints
+export async function createComplaint(payload) {
+  const res = await api.post("/complaints", payload);
+  return res.data;
+}
+
+export async function getComplaints(params = {}) {
+  const res = await api.get("/complaints", { params });
+  return res.data;
+}
+
+export async function addComplaintComment(complaintId, payload) {
+  const res = await api.post(`/complaints/${complaintId}/comments`, payload);
+  return res.data;
+}
+
+export async function getComplaintById(id) {
+  const res = await api.get(`/complaints/${id}`);
+  return res.data;
+}
+
+export async function getComplaintComments(complaintId) {
+  const res = await api.get(`/complaints/${complaintId}/comments`);
+  return res.data;
+}
+
 export function toAbsoluteUrl(path) {
   if (!path) return path;
   if (/^https?:\/\//i.test(path)) return path;


### PR DESCRIPTION
…the React app

- surface friendly status banners in CheckStatus, including the new rejected state
- extend the backend enum and migrations so “rejected” complaints are fully supported